### PR TITLE
Fix unit test on MS platforms

### DIFF
--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/getservice/GetServiceGetApplicationsTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/getservice/GetServiceGetApplicationsTest.java
@@ -207,7 +207,7 @@ public class GetServiceGetApplicationsTest {
                 "    - serviceomega\n" +
                 "    stack: nope\n" +
                 "    timeout: 987654321\n" +
-                "  path: /test/uri\n"
+                "  path: " + Paths.get("/test/uri").toString() + "\n"
         ));
     }
 


### PR DESCRIPTION
Turned out Windows renders `Path` objects not with `/`, but `\\` for some reason...